### PR TITLE
Fix anaconda auto repos

### DIFF
--- a/SOURCES/CentOS-Base.repo
+++ b/SOURCES/CentOS-Base.repo
@@ -27,21 +27,3 @@ gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
-#additional packages that may be useful
-[extras]
-name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
-#baseurl=http://mirror.centos.org/$contentdir/$releasever/extras/$basearch/
-gpgcheck=1
-enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-
-#additional packages that extend functionality of existing packages
-[centosplus]
-name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
-#baseurl=http://mirror.centos.org/$contentdir/$releasever/centosplus/$basearch/
-gpgcheck=1
-enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-

--- a/SOURCES/CentOS-Extras.repo
+++ b/SOURCES/CentOS-Extras.repo
@@ -1,0 +1,30 @@
+# CentOS-Extras.repo
+#
+# The mirror system uses the connecting IP address of the client and the
+# update status of each mirror to pick mirrors that are updated to and
+# geographically close to the client.  You should use this for CentOS updates
+# unless you are manually picking other mirrors.
+#
+# If the mirrorlist= does not work for you, as a fall back you can try the
+# remarked out baseurl= line instead.
+#
+#
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/extras/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+

--- a/SOURCES/anaconda-make-service-repos.sh
+++ b/SOURCES/anaconda-make-service-repos.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+########################################################################
+# Anaconda uses a custom yum root, so we need to link our custom
+# vars into there
+########################################################################
+SELFCOPIES=${1:-0}
+TRIGGERCOPIES=${2:-0}
+########################################################################
+echo '[Unit]' > /usr/lib/systemd/system/anaconda-repos.service
+echo 'ConditionPathExists=/etc/anaconda.repos.d' >> /usr/lib/systemd/system/anaconda-repos.service
+echo 'Description=Setup CentOS Anaconda repos' >> /usr/lib/systemd/system/anaconda-repos.service
+echo '[Install]' >> /usr/lib/systemd/system/anaconda-repos.service
+echo 'WantedBy=anaconda.target' >> /usr/lib/systemd/system/anaconda-repos.service
+echo '[Service]' >> /usr/lib/systemd/system/anaconda-repos.service
+echo 'ExecStart=/usr/libexec/centos-release/anaconda-repos.sh' >> /usr/lib/systemd/system/anaconda-repos.service
+
+########################################################################
+systemctl enable anaconda-repos.service
+########################################################################
+

--- a/SOURCES/anaconda-repos.sh
+++ b/SOURCES/anaconda-repos.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+########################################################################
+# anaconda expects some specific reponames, so we are going to make them
+########################################################################
+sed -e 's/\[base\]/[centos]/' /etc/yum.repos.d/CentOS-Base.repo > /etc/anaconda.repos.d/centos.repo
+
+########################################################################
+# anaconda uses a custom yum root, so setup the relevant yumvars
+########################################################################
+mkdir -p /tmp/yum.root/etc/yum/vars
+cp /etc/yum/vars/* /tmp/yum.root/etc/yum/vars/
+

--- a/SPECS/centos-release.spec
+++ b/SPECS/centos-release.spec
@@ -27,6 +27,9 @@
 #define beta Beta
 %define dist .el%{dist_release_version}
 
+# The anaconda scripts in %{_libexecdir} can create false requirements
+%global __requires_exclude_from %{_libexecdir}
+
 Name:           centos-release
 Version:        %{base_release_version}
 Release:        %{centos_rel}.0.4%{?dist}
@@ -73,6 +76,9 @@ Source304:      CentOS-fasttrack.repo
 Source305:      CentOS-Media.repo
 Source306:      CentOS-Sources.repo
 Source307:      CentOS-Vault.repo
+
+Source400:      anaconda-make-service-repos.sh
+Source401:      anaconda-repos.sh
 
 %ifarch %{arm}
 %description -n %{pkg_name}
@@ -182,6 +188,10 @@ install -m 0644 %{SOURCE1} %{buildroot}/%{_prefix}/lib/systemd/system-preset/
 install -m 0644 %{SOURCE2} %{buildroot}/%{_prefix}/lib/systemd/system-preset/
 install -m 0644 %{SOURCE3} %{buildroot}/%{_prefix}/lib/systemd/system-preset/
 
+# Drop in scripts for anaconda repos
+install -m 0750 %{SOURCE400} %{buildroot}/%{_libexecdir}/%{name}/anaconda-make-service-repos.sh
+install -m 0750 %{SOURCE401} %{buildroot}/%{_libexecdir}/%{name}/anaconda-repos.sh
+
 %ifarch %{arm}
 # Install armhfp specific tools
 mkdir -p %{buildroot}/%{_bindir}/
@@ -192,6 +202,8 @@ install -m 0755 %{SOURCE100} %{buildroot}%{_bindir}/
 
 %clean
 rm -rf %{buildroot}
+
+%triggerin -p %{_libexecdir}/%{name}/anaconda-make-services.sh -- anaconda
 
 %files -n %{pkg_name}
 %defattr(0644,root,root,0755)

--- a/SPECS/centos-release.spec
+++ b/SPECS/centos-release.spec
@@ -68,10 +68,11 @@ Source202:      Contributors
 Source300:      CentOS-Base.repo
 Source301:      CentOS-CR.repo
 Source302:      CentOS-Debuginfo.repo
-Source303:      CentOS-fasttrack.repo
-Source304:      CentOS-Media.repo
-Source305:      CentOS-Sources.repo
-Source306:      CentOS-Vault.repo
+Source303:      CentOS-Extras.repo
+Source304:      CentOS-fasttrack.repo
+Source305:      CentOS-Media.repo
+Source306:      CentOS-Sources.repo
+Source307:      CentOS-Vault.repo
 
 %ifarch %{arm}
 %description -n %{pkg_name}
@@ -142,6 +143,7 @@ install -m 644 %{SOURCE303} %{buildroot}/etc/yum.repos.d
 install -m 644 %{SOURCE304} %{buildroot}/etc/yum.repos.d
 install -m 644 %{SOURCE305} %{buildroot}/etc/yum.repos.d
 install -m 644 %{SOURCE306} %{buildroot}/etc/yum.repos.d
+install -m 644 %{SOURCE307} %{buildroot}/etc/yum.repos.d
 
 mkdir -p -m 755 %{buildroot}/etc/dnf/vars
 echo "%{infra_var}" > %{buildroot}/etc/dnf/vars/infra


### PR DESCRIPTION
These two commits will setup anaconda to automatically use the CentOS mirrors for netinstall media.

The resulting behavior will be similar to Fedora's net installation.

Anaconda will not permit duplicate repo names, or expose extra repos defined in /etc/anaconda.repos.d/ so I had to seperate out Extras and Plus so that they can be defined by other means.